### PR TITLE
add travis build status icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/dlang/undeaD.svg?branch=master)](https://travis-ci.org/dlang/undeaD)
+
 undeaD
 ======
 


### PR DESCRIPTION
~~there needs to be a new commit after travis is enabled for it to actually start testing, so why not have it be adding the status icon :)~~

Adds a test status icon to README.md