### PR TITLE
Update to build and test on Windows, including x86_64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,10 @@
 *.i*86
 *.x86_64
 *.hex
+
+# Extra dirs/build files
+bin
+obj
+.dub
+.vs
+undead.sln

--- a/src/undead/date.d
+++ b/src/undead/date.d
@@ -832,7 +832,7 @@ extern(C) void std_date_static_this()
     localTZA = getLocalTZA();
 }
 
-version (Win32)
+version (Windows)
 {
     private import core.sys.windows.windows;
     //import c.time;

--- a/src/undead/doformat.d
+++ b/src/undead/doformat.d
@@ -1321,7 +1321,7 @@ unittest
 
     void myPrint(...)
     {
-        std.format.doFormat(&putc, _arguments, _argptr);
+        undead.doformat.doFormat(&putc, _arguments, _argptr);
     }
 
     myPrint("The answer is %s:", 27, 6);

--- a/src/undead/stream.d
+++ b/src/undead/stream.d
@@ -1979,7 +1979,7 @@ class File: Stream {
     readable = cast(bool)(mode & FileMode.In);
     writeable = cast(bool)(mode & FileMode.Out);
     version (Windows) {
-      hFile = CreateFileW(filename.tempCStringW(), access, share,
+      hFile = CreateFileW(filename.tempCString!wchar(), access, share,
                           null, createMode, 0, null);
       isopen = hFile != INVALID_HANDLE_VALUE;
     }

--- a/win64.mak
+++ b/win64.mak
@@ -11,7 +11,7 @@ B=bin
 
 TARGET=undead
 
-DFLAGS=-g -Isrc/
+DFLAGS=-m64 -g -Isrc/
 LFLAGS=-L/map/co
 #DFLAGS=
 #LFLAGS=


### PR DESCRIPTION
The change in date.d allows compilation on both Win64 and Win32.

The change in stream.d is not obvious but tempCStringW() corrupts
the filename where tempCString!wchar() works. This is possibly a
generic bug in std.string

Simple change in doformat.d to call the local copy of doFormat
and get rid of the deprecation warning in Phobos

Added the win64.make alongside win32, although dub allows building
and testing Win64 already.

Plus some extra .gitignore stuff for VisualD and dub.