### PR TITLE
Add Meson build definition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: d
+dist: trusty
+sudo: false
 
 os:
   - linux
@@ -8,4 +10,23 @@ d:
   - dmd
   - ldc
 
-sudo: false
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install ninja python3; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip3 install meson; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then pip3 install meson; fi
+
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then mkdir .ntmp && curl -L https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip -o .ntmp/ninja-linux.zip; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then unzip .ntmp/ninja-linux.zip -d .ntmp; fi
+
+before_script:
+  - export PATH=$PATH:$PWD/.ntmp
+
+script:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then meson build && ninja -C build; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ninja -C build test -v; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then SDKROOT=$(xcodebuild -version -sdk macosx Path) meson build && ninja -C build test; fi
+  - dub build
+  - dub test

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,59 @@
+project('undeaD', 'd')
+
+project_version   = '1.0.7'
+project_soversion = '0'
+
+src_dir = include_directories('src/')
+pkgc = import('pkgconfig')
+
+undead_src = [
+    'src/undead/stream.d',
+    'src/undead/string.d',
+    'src/undead/dateparse.d',
+    'src/undead/regexp.d',
+    'src/undead/doformat.d',
+    'src/undead/cstream.d',
+    'src/undead/date.d',
+    'src/undead/socketstream.d',
+    'src/undead/datebase.d',
+    'src/undead/metastrings.d',
+    'src/undead/bitarray.d'
+]
+
+undead_internal_src = [
+    'src/undead/internal/file.d',
+]
+
+install_headers(undead_src, subdir: 'd/undead')
+install_headers(undead_internal_src, subdir: 'd/undead/internal')
+
+# we only build a static library here
+undead_lib = library('undead',
+        [undead_src,
+         undead_internal_src],
+        include_directories: [src_dir],
+        install: true,
+        version: project_version,
+        soversion: project_soversion
+)
+pkgc.generate(name: 'undead',
+              libraries: undead_lib,
+              subdirs: 'd/',
+              version: project_version,
+              description: 'Obsolete Phobos modules, back from the dead.'
+)
+
+# Tests
+# We need to manually create a main () routine, since LDC will break with split compilation and -main flag
+fake_main_src = meson.build_root() + '/umain.d'
+r = run_command('sh', '-c', 'echo "void main () {}" > ' + fake_main_src)
+if r.returncode() != 0
+  error('Unable to write dummy main.d file: ' + r.stderr().strip())
+endif
+
+undead_test_exe = executable('undead_test',
+    [undead_src, undead_internal_src, fake_main_src],
+    include_directories: [src_dir],
+    d_args: meson.get_compiler('d').unittest_args()
+)
+test('undead_tests', undead_test_exe)


### PR DESCRIPTION
This adds a Meson build definition to this project, to allow projects using Meson to easily use it, and to make packaging undeaD in Linux distributions like Debian and Fedora much easier.
(Meson is already well supported in Debian, we need to have D include files installed properly, and having a pkg-config file is very useful to help other tools find the library when building)

The build can be tested by installing Meson, then running:
```
mkdir b && cd b
meson ..
ninja
DESTDIR=/tmp/test_install ninja install
```

You can learn more about Meson here: http://mesonbuild.com/