### PR TITLE
Remove travis-ci badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/dlang/undeaD.svg?branch=master)](https://travis-ci.org/dlang/undeaD)
-
 undeaD
 ======
 


### PR DESCRIPTION
TravisCI has ceased to work since the migration to dotcom.