### PR TITLE
Fix dip1000 deprecation

### DIFF
--- a/src/undead/xml.d
+++ b/src/undead/xml.d
@@ -2955,7 +2955,7 @@ private alias Err = CheckException;
 
 private
 {
-    inout(T) toType(T)(inout Object o)
+    inout(T) toType(T)(inout return scope Object o)
     {
         T t = cast(T)(o);
         if (t is null)


### PR DESCRIPTION
Needed to unblock buildkite on https://github.com/dlang/dmd/pull/14089, since deprecations are treated as errors.
```
src/undead/xml.d(594,55): Deprecation: scope variable `o` assigned to non-scope parameter `o`
src/undead/xml.d(614,55): Deprecation: scope variable `o` assigned to non-scope parameter `o`
src/undead/xml.d(845,54): Deprecation: scope variable `o` assigned to non-scope parameter `o`
src/undead/xml.d(869,54): Deprecation: scope variable `o` assigned to non-scope parameter `o`
src/undead/xml.d(1280,48): Deprecation: scope variable `o` assigned to non-scope parameter `o`
src/undead/xml.d(1299,48): Deprecation: scope variable `o` assigned to non-scope parameter `o`
src/undead/xml.d(1368,48): Deprecation: scope variable `o` assigned to non-scope parameter `o`
src/undead/xml.d(1387,48): Deprecation: scope variable `o` assigned to non-scope parameter `o`
src/undead/xml.d(1445,48): Deprecation: scope variable `o` assigned to non-scope parameter `o`
src/undead/xml.d(1464,48): Deprecation: scope variable `o` assigned to non-scope parameter `o`
src/undead/xml.d(1528,48): Deprecation: scope variable `o` assigned to non-scope parameter `o`
src/undead/xml.d(1547,48): Deprecation: scope variable `o` assigned to non-scope parameter `o`
src/undead/xml.d(1608,48): Deprecation: scope variable `o` assigned to non-scope parameter `o`
src/undead/xml.d(1627,48): Deprecation: scope variable `o` assigned to non-scope parameter `o`
```