### PR TITLE
Disable doFormat under GNU compiler.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,19 +30,45 @@ jobs:
         # Latest stable version, update at will
         os: [ macOS-10.15, ubuntu-20.04, windows-2019 ]
         dc: [ dmd-latest, ldc-latest, dmd-master, ldc-master ]
+        include:
+          - os: ubuntu-20.04
+            dc: gdc-10
 
     runs-on: ${{ matrix.os }}
     steps:
 
     - name: Install D compiler - ${{ matrix.dc }}
+      if: ${{ matrix.dc != 'gdc-10' }}
       uses: dlang-community/setup-dlang@v1
       with:
         compiler: ${{ matrix.dc }}
 
+    - name: Install latest DMD (for dub)
+      if: ${{ matrix.dc == 'gdc-10' }}
+      uses: dlang-community/setup-dlang@v1
+      with:
+        compiler: dmd-latest
+
+    - name: Install GDC via apt-get
+      if: ${{ matrix.dc == 'gdc-10' }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install ${{ matrix.dc }} -y
+
     - name: Checkout
       uses: actions/checkout@v2
 
+    # avoids issue with setup-dlang setting DC
     - name: 'Build and Test'
+      if: ${{ matrix.dc == 'gdc-10' }}
+      shell: bash
+      run: |
+        gdc-10 --version
+        dub build --compiler=gdc-10
+        dub test --compiler=gdc-10 -v
+
+    - name: 'Build and Test'
+      if: ${{ matrix.dc != 'gdc-10' }}
       shell: bash
       run: |
         $DC --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         # Latest stable version, update at will
-        os: [ macOS-10.15, ubuntu-20.04, windows-2019 ]
+        os: [ macOS-11, ubuntu-20.04, windows-2019 ]
         dc: [ dmd-latest, ldc-latest, dmd-master, ldc-master ]
         include:
           - os: ubuntu-20.04

--- a/src/undead/doformat.d
+++ b/src/undead/doformat.d
@@ -390,6 +390,11 @@ void main()
  */
 void doFormat()(scope void delegate(dchar) putc, TypeInfo[] arguments, va_list ap)
 {
+    version (GNU)
+    {
+        static assert(false, "GNU D compiler does not support doFormat");
+    }
+
     import std.utf : encode, toUCSindex, isValidDchar, UTFException, toUTF8;
     import core.stdc.string : strlen;
     import core.stdc.stdlib : alloca, malloc, realloc, free;
@@ -1266,6 +1271,7 @@ private bool needToSwapEndianess(Char)(ref FormatSpec!Char f)
         || endian == Endian.bigEndian && f.flDash;
 }
 
+version(GNU) {} else
 unittest
 {
     string res;

--- a/src/undead/stream.d
+++ b/src/undead/stream.d
@@ -1434,43 +1434,46 @@ class Stream : InputStream, OutputStream {
     assert (chars == "three", chars);
   }
 
-  unittest { //unit tests for Issue 1668
-    void tryFloatRoundtrip(float x, string fmt = "", string pad = "") {
-      auto s = new MemoryStream();
-      s.writef(fmt, x, pad);
-      s.position = 0;
+  version (GNU) {} else
+  {
+    unittest { //unit tests for Issue 1668
+      void tryFloatRoundtrip(float x, string fmt = "", string pad = "") {
+        auto s = new MemoryStream();
+        s.writef(fmt, x, pad);
+        s.position = 0;
 
-      float f;
-      assert(s.readf(&f));
-      assert(x == f || (x != x && f != f)); //either equal or both NaN
+        float f;
+        assert(s.readf(&f));
+        assert(x == f || (x != x && f != f)); //either equal or both NaN
+      }
+
+      tryFloatRoundtrip(1.0);
+      tryFloatRoundtrip(1.0, "%f");
+      tryFloatRoundtrip(1.0, "", " ");
+      tryFloatRoundtrip(1.0, "%f", " ");
+
+      tryFloatRoundtrip(3.14);
+      tryFloatRoundtrip(3.14, "%f");
+      tryFloatRoundtrip(3.14, "", " ");
+      tryFloatRoundtrip(3.14, "%f", " ");
+
+      float nan = float.nan;
+      tryFloatRoundtrip(nan);
+      tryFloatRoundtrip(nan, "%f");
+      tryFloatRoundtrip(nan, "", " ");
+      tryFloatRoundtrip(nan, "%f", " ");
+
+      float inf = 1.0/0.0;
+      tryFloatRoundtrip(inf);
+      tryFloatRoundtrip(inf, "%f");
+      tryFloatRoundtrip(inf, "", " ");
+      tryFloatRoundtrip(inf, "%f", " ");
+
+      tryFloatRoundtrip(-inf);
+      tryFloatRoundtrip(-inf,"%f");
+      tryFloatRoundtrip(-inf, "", " ");
+      tryFloatRoundtrip(-inf, "%f", " ");
     }
-
-    tryFloatRoundtrip(1.0);
-    tryFloatRoundtrip(1.0, "%f");
-    tryFloatRoundtrip(1.0, "", " ");
-    tryFloatRoundtrip(1.0, "%f", " ");
-
-    tryFloatRoundtrip(3.14);
-    tryFloatRoundtrip(3.14, "%f");
-    tryFloatRoundtrip(3.14, "", " ");
-    tryFloatRoundtrip(3.14, "%f", " ");
-
-    float nan = float.nan;
-    tryFloatRoundtrip(nan);
-    tryFloatRoundtrip(nan, "%f");
-    tryFloatRoundtrip(nan, "", " ");
-    tryFloatRoundtrip(nan, "%f", " ");
-
-    float inf = 1.0/0.0;
-    tryFloatRoundtrip(inf);
-    tryFloatRoundtrip(inf, "%f");
-    tryFloatRoundtrip(inf, "", " ");
-    tryFloatRoundtrip(inf, "%f", " ");
-
-    tryFloatRoundtrip(-inf);
-    tryFloatRoundtrip(-inf,"%f");
-    tryFloatRoundtrip(-inf, "", " ");
-    tryFloatRoundtrip(-inf, "%f", " ");
   }
 }
 
@@ -2773,24 +2776,27 @@ class MemoryStream: TArrayStream!(ubyte[]) {
     assert (m.position == 42);
     m.position = 0;
     assert (m.available == 42);
-    m.writef("%d %d %s",100,345,"hello");
-    auto str = m.toString();
-    assert (str[0..13] == "100 345 hello", str[0 .. 13]);
-    assert (m.available == 29);
-    assert (m.position == 13);
+    version (GNU) {} else // writef not allowed in GNU
+    {
+      m.writef("%d %d %s",100,345,"hello");
+      auto str = m.toString();
+      assert (str[0..13] == "100 345 hello", str[0 .. 13]);
+      assert (m.available == 29);
+      assert (m.position == 13);
 
-    MemoryStream m2;
-    m.position = 3;
-    m2 = new MemoryStream ();
-    m2.writeString("before");
-    m2.copyFrom(m,10);
-    str = m2.toString();
-    assert (str[0..16] == "before 345 hello");
-    m2.position = 3;
-    m2.copyFrom(m);
-    auto str2 = m.toString();
-    str = m2.toString();
-    assert (str == ("bef" ~ str2));
+      MemoryStream m2;
+      m.position = 3;
+      m2 = new MemoryStream ();
+      m2.writeString("before");
+      m2.copyFrom(m,10);
+      str = m2.toString();
+      assert (str[0..16] == "before 345 hello");
+      m2.position = 3;
+      m2.copyFrom(m);
+      auto str2 = m.toString();
+      str = m2.toString();
+      assert (str == ("bef" ~ str2));
+    }
   }
 }
 

--- a/src/undead/stream.d
+++ b/src/undead/stream.d
@@ -339,6 +339,9 @@ interface OutputStream {
    * Print a formatted string into the stream using writef-style syntax.
    * References: <a href="std_format.html">std.format</a>.
    * Returns: self to chain with other stream commands like flush.
+   *
+   * NOTE: not supported in GDC, since it uses features unimplemented in that
+   * compiler.
    */
   OutputStream writef(...);
   OutputStream writefln(...); /// ditto
@@ -1206,10 +1209,17 @@ class Stream : InputStream, OutputStream {
 
   // writes data with optional trailing newline
   OutputStream writefx(TypeInfo[] arguments, va_list argptr, int newline=false) {
-    doFormat(&doFormatCallback,arguments,argptr);
-    if (newline)
-      writeLine("");
-    return this;
+    version (GNU)
+    {
+      assert(false, "GNU D compiler does not support doFormat");
+    }
+    else
+    {
+      doFormat(&doFormatCallback,arguments,argptr);
+      if (newline)
+        writeLine("");
+      return this;
+    }
   }
 
   /***


### PR DESCRIPTION
Remove unittest and compilation for GNU compiler. Instead of obscure error from druntime internals, this provides a static assert.

Should fix #55 and obsolete #54 

Note: the problem with doFormat is that it uses a specific form of `va_arg` that GDC does not support. A future edit to this library can re-enable if someone figures out how to use the templated form:

```d
va_list argptr;
int arg;
arg = va_arg!int(argptr); // OK
va_arg(argptr, typeid(int), &arg); // Not OK
```

But I think we can merge this now, and if we have people looking for support, they can submit a further PR to re-enable with the correct changes. However, eschewing all undead support from GDC for this one module is not worth it.

For reference, here is the function that is disabled for GDC: https://github.com/dlang/dmd/blob/f2b3b97eb327a1d409decd2510950d91ec35fb52/druntime/src/core/vararg.d#L22